### PR TITLE
[MAINT] Update Ubuntu runner versions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -63,7 +63,7 @@ jobs:
 
   test_conda:
     timeout-minutes: 90
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -el {0}


### PR DESCRIPTION
Ubuntu-20.04 hosted runner image is closing down, so updates to newer version.